### PR TITLE
Feature #28 implementation; Model types

### DIFF
--- a/box/configs/mappings/grpc_mongo.json
+++ b/box/configs/mappings/grpc_mongo.json
@@ -2,88 +2,105 @@
    "data":[{
         "opType": "directories",
         "src": "models",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "directories",
         "src": "interfaces",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "directories", 
         "src": "database",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "directories",
         "src": "handlers",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "directories",
         "src": "protos",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "directories",
         "src": "scripts",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
     {
         "opType": "static-files",
         "src": "lang/go/static/common/databases/mongo/database.static",
-        "dst": "database/database.go"
+        "dst": "database/database.go",
+        "genForType":""
     },
     {
         "opType": "static-files",
         "src": "lang/go/static/http/helper/helper.static",
-        "dst": "helper/helper.go"
+        "dst": "helper/helper.go",
+        "genForType":""
     },
     {
         "opType": "multiple-file-templates",
         "src": "lang/go/templates/common/models",
-        "dst": "models"
+        "dst": "models",
+        "genForType":"both"
     },
     {
         "opType": "multiple-file-templates",
         "src": "lang/go/templates/common/interfaces",
-        "dst": "interfaces"
+        "dst": "interfaces",
+        "genForType":"main"
     },
     {
         "opType": "multiple-file-templates",
         "src": "lang/go/templates/common/database/mongo/db",
-        "dst": "database"
+        "dst": "database",
+        "genForType":"main"
     },
     {
         "opType": "multiple-file-templates",
         "src": "lang/go/templates/grpc/handlers",
-        "dst": "handlers"
+        "dst": "handlers",
+        "genForType":"main"
     },
      {
         "opType": "multiple-file-templates",
         "src": "lang/go/templates/grpc/protofile",
         "dst": "protos",
-        "ext":"proto"
+        "ext":"proto",
+        "genForType":"both"
     },
     {
         "opType": "single-file-templates",
         "src": "lang/go/templates/grpc/main",
-        "dst": "main.go"
+        "dst": "main.go",
+        "genForType":""
     },
     {
         "opType": "single-file-templates",
         "src": "lang/go/templates/common/docker-compose",
-        "dst": "docker-compose.yaml"
+        "dst": "docker-compose.yaml",
+        "genForType":""
     },
     {
         "opType": "single-file-templates",
         "src": "lang/go/templates/common/Dockerfile",
-        "dst": "Dockerfile"
+        "dst": "Dockerfile",
+        "genForType":""
     },
     {
         "opType": "exec",
         "src": "lang/go/templates/common/init.exec",
-        "dst": "scripts/init.sh"
+        "dst": "scripts/init.sh",
+        "genForType":""
     }
 ]
 }

--- a/box/configs/mappings/grpc_mongo_nats.json
+++ b/box/configs/mappings/grpc_mongo_nats.json
@@ -3,22 +3,26 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
@@ -28,83 +32,99 @@
         {
             "opType": "directories",
             "src": "messaging",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/mongo/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/connection.static",
-            "dst": "messaging/connection.go"
+            "dst": "messaging/connection.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/messaging.static",
-            "dst": "messaging/messaging.go"
+            "dst": "messaging/messaging.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/models/models.static",
-            "dst": "models/models.go"
+            "dst": "models/models.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+             "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/mongo/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/grpc/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/grpc/protofile",
             "dst": "protos",
-            "ext": "proto"
+            "ext": "proto",
+            "genForType":"both"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/grpc/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/configs/mappings/grpc_mysql.json
+++ b/box/configs/mappings/grpc_mysql.json
@@ -2,22 +2,26 @@
     "data":[{
          "opType": "directories",
          "src": "models",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
          "src": "interfaces",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories", 
          "src": "database",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
          "src": "handlers",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
@@ -27,63 +31,75 @@
      {
         "opType": "directories",
         "src": "scripts",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
      {
         "opType": "static-files",
         "src": "lang/go/static/common/databases/sql/mysql/database.static",
-        "dst": "database/database.go"
+        "dst": "database/database.go",
+        "genForType":""
     },
      {
          "opType": "static-files",
          "src": "lang/go/static/http/helper/helper.static",
-         "dst": "helper/helper.go"
+         "dst": "helper/helper.go",
+         "genForType":""
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/models",
-         "dst": "models"
+         "dst": "models",
+         "genForType":"both"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/interfaces",
-         "dst": "interfaces"
+         "dst": "interfaces",
+         "genForType":"main"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/database/sql/db",
-         "dst": "database"
+         "dst": "database",
+         "genForType":"main"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/grpc/handlers",
-         "dst": "handlers"
+         "dst": "handlers",
+         "genForType":"main"
      },
       {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/grpc/protofile",
          "dst": "protos",
-         "ext":"proto"
+         "ext":"proto",
+         "genForType":"both"
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/grpc/main",
-         "dst": "main.go"
+         "dst": "main.go",
+         "genForType":""
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/common/docker-compose",
-         "dst": "docker-compose.yaml"
+         "dst": "docker-compose.yaml",
+         "genForType":""
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/common/Dockerfile",
-         "dst": "Dockerfile"
+         "dst": "Dockerfile",
+         "genForType":""
      },
      {
          "opType": "exec",
          "src": "lang/go/templates/common/init.exec",
-         "dst": "scripts/init.sh"
+         "dst": "scripts/init.sh",
+         "genForType":""
      }
  ]
  }

--- a/box/configs/mappings/grpc_postgres.json
+++ b/box/configs/mappings/grpc_postgres.json
@@ -2,88 +2,105 @@
     "data":[{
          "opType": "directories",
          "src": "models",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
          "src": "interfaces",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories", 
          "src": "database",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
          "src": "handlers",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
          "opType": "directories",
          "src": "protos",
-         "dst": ""
+         "dst": "",
+         "genForType":""
      },
      {
         "opType": "directories",
         "src": "scripts",
-        "dst": ""
+        "dst": "",
+        "genForType":""
     },
      {
         "opType": "static-files",
         "src": "lang/go/static/common/databases/sql/postgres/database.static",
-        "dst": "database/database.go"
+        "dst": "database/database.go",
+        "genForType":""
     },
      {
          "opType": "static-files",
          "src": "lang/go/static/http/helper/helper.static",
-         "dst": "helper/helper.go"
+         "dst": "helper/helper.go",
+         "genForType":""
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/models",
-         "dst": "models"
+         "dst": "models",
+         "genForType":"both"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/interfaces",
-         "dst": "interfaces"
+         "dst": "interfaces",
+         "genForType":"main"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/common/database/sql/db",
-         "dst": "database"
+         "dst": "database",
+         "genForType":"main"
      },
      {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/grpc/handlers",
-         "dst": "handlers"
+         "dst": "handlers",
+         "genForType":"main"
      },
       {
          "opType": "multiple-file-templates",
          "src": "lang/go/templates/grpc/protofile",
          "dst": "protos",
-         "ext":"proto"
+         "ext":"proto",
+         "genForType":"both"
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/grpc/main",
-         "dst": "main.go"
+         "dst": "main.go",
+         "genForType":""
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/common/docker-compose",
-         "dst": "docker-compose.yaml"
+         "dst": "docker-compose.yaml",
+         "genForType":""
      },
      {
          "opType": "single-file-templates",
          "src": "lang/go/templates/common/Dockerfile",
-         "dst": "Dockerfile"
+         "dst": "Dockerfile",
+         "genForType":""
      },
      {
          "opType": "exec",
          "src": "lang/go/templates/common/init.exec",
-         "dst": "scripts/init.sh"
+         "dst": "scripts/init.sh",
+         "genForType":""
      }
  ]
  }

--- a/box/configs/mappings/http_mongo.json
+++ b/box/configs/mappings/http_mongo.json
@@ -3,22 +3,26 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":"main"
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":"main"
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":"main"
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":"main"
         },
         {
             "opType": "directories",
@@ -27,23 +31,21 @@
         },
         {
             "opType": "directories",
-            "src": "protos",
-            "dst": ""
-        },
-        {
-            "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":"main"
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/mongo/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":"main"
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/global/functions.go",
-            "dst": "global/functions.go"
+            "dst": "global/functions.go",
+            "genForType":"main"
         },
         {
             "opType": "static-files",
@@ -53,47 +55,56 @@
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/mongo/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":"main"
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":"main"
         }
     ]
 }

--- a/box/configs/mappings/http_mongo_nats.json
+++ b/box/configs/mappings/http_mongo_nats.json
@@ -3,112 +3,134 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "global",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "messaging",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/mongo/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/global/functions.go",
-            "dst": "global/functions.go"
+            "dst": "global/functions.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/connection.static",
-            "dst": "messaging/connection.go"
+            "dst": "messaging/connection.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/messaging.static",
-            "dst": "messaging/messaging.go"
+            "dst": "messaging/messaging.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/models/models.static",
-            "dst": "models/models.go"
+            "dst": "models/models.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/mongo/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/configs/mappings/http_mysql.json
+++ b/box/configs/mappings/http_mysql.json
@@ -3,82 +3,98 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/sql/mysql/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/sql/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/emplates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/configs/mappings/http_mysql_nats.json
+++ b/box/configs/mappings/http_mysql_nats.json
@@ -3,17 +3,20 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
@@ -23,91 +26,109 @@
         {
             "opType": "directories",
             "src": "global",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "messaging",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/sql/mysql/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/global/functions.go",
-            "dst": "global/functions.go"
+            "dst": "global/functions.go",
+            "genForType":""
         },{
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/connection.static",
-            "dst": "messaging/connection.go"
+            "dst": "messaging/connection.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/messaging.static",
-            "dst": "messaging/messaging.go"
+            "dst": "messaging/messaging.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/models/models.static",
-            "dst": "models/models.go"
+            "dst": "models/models.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/sql/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/configs/mappings/http_postgres.json
+++ b/box/configs/mappings/http_postgres.json
@@ -3,87 +3,104 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "global",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/sql/postgres/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/sql/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/configs/mappings/http_postgres_nats.json
+++ b/box/configs/mappings/http_postgres_nats.json
@@ -3,111 +3,133 @@
         {
             "opType": "directories",
             "src": "models",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "interfaces",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories", 
             "src": "database",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "handlers",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "global",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "directories",
             "src": "messaging",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
          {
             "opType": "directories",
             "src": "scripts",
-            "dst": ""
+            "dst": "",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/databases/sql/postgres/database.static",
-            "dst": "database/database.go"
+            "dst": "database/database.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/common/global/functions.go",
-            "dst": "global/functions.go"
+            "dst": "global/functions.go",
+            "genForType":""
         },{
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/connection.static",
-            "dst": "messaging/connection.go"
+            "dst": "messaging/connection.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/messaging/nats/messaging.static",
-            "dst": "messaging/messaging.go"
+            "dst": "messaging/messaging.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/http/helper/helper.static",
-            "dst": "helper/helper.go"
+            "dst": "helper/helper.go",
+            "genForType":""
         },
         {
             "opType": "static-files",
             "src": "lang/go/static/models/models.static",
-            "dst": "models/models.go"
+            "dst": "models/models.go",
+            "genForType":""
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/models",
-            "dst": "models"
+            "dst": "models",
+            "genForType":"both"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/interfaces",
-            "dst": "interfaces"
+            "dst": "interfaces",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/common/database/sql/db",
-            "dst": "database"
+            "dst": "database",
+            "genForType":"main"
         },
         {
             "opType": "multiple-file-templates",
             "src": "lang/go/templates/http/handlers",
-            "dst": "handlers"
+            "dst": "handlers",
+            "genForType":"main"
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/config",
-            "dst": "application.json"
+            "dst": "application.json",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/http/main",
-            "dst": "main.go"
+            "dst": "main.go",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/docker-compose",
-            "dst": "docker-compose.yaml"
+            "dst": "docker-compose.yaml",
+            "genForType":""
         },
         {
             "opType": "single-file-templates",
             "src": "lang/go/templates/common/Dockerfile",
-            "dst": "Dockerfile"
+            "dst": "Dockerfile",
+            "genForType":""
         },
         {
             "opType": "exec",
             "src": "lang/go/templates/common/init.exec",
-            "dst": "scripts/init.sh"
+            "dst": "scripts/init.sh",
+            "genForType":""
         }
     ]
 }

--- a/box/lang/go/templates/common/init.exec
+++ b/box/lang/go/templates/common/init.exec
@@ -29,3 +29,5 @@ cd {{$.config.Project}}
  go mod init {{$.config.Project}}
 
  go mod tidy
+
+ go build ./...

--- a/box/lang/go/templates/grpc/main
+++ b/box/lang/go/templates/grpc/main
@@ -62,6 +62,7 @@ session, err := database.GetConnection(DBConnection, DBName)
 	server := grpc.NewServer()
 
 	 {{- range $.config.Models }}
+	 {{- if eq .Type "main" }}
      {{.Name | ToLower}} := new(handlers.{{.Name}})
 	 {{.Name | ToLower}}.I{{.Name}} = &database.{{.Name}}DB{DB: session}
 	 {{- if .MessagingModelSpec.MessageRespondType}}
@@ -71,6 +72,7 @@ session, err := database.GetConnection(DBConnection, DBName)
 	 pb.Register{{.Name}}Server(server, {{.Name | ToLower}})	
      {{- end}}
 	 // Register reflection service on gRPC server.
+	 {{- end}}
 	reflection.Register(server)
 	if err := server.Serve(lis); err != nil {
 		glog.Fatalf("failed to serve: %v", err)

--- a/box/lang/go/templates/grpc/protofile
+++ b/box/lang/go/templates/grpc/protofile
@@ -19,7 +19,7 @@ option go_package = "{{.Project}}/protos";
     {{- $Count = $Count | Counter}}
 	{{- end}}
 	}
-
+ {{- if eq .Model.Type "main" }}
 message {{.Model.Name}}Response{
 		int32 code=1;
 		string error=2;
@@ -51,3 +51,5 @@ service {{ .Model.Name}} {
 	rpc Get{{.Model.Name}}ByID ({{.Model.Name}}IDRequest) returns({{.Model.Name}}Type);
 	rpc GetAll{{.Model.Name}}sBy ({{.Model.Name}}GetAllByRequest) returns({{.Model.Name}}sResponse);
 }
+
+{{- end}}

--- a/box/lang/go/templates/http/main
+++ b/box/lang/go/templates/http/main
@@ -62,6 +62,7 @@ glog.Info("Application {{$.config.Project}} has started")
 	})
 
      {{ range $.config.Models }}
+	 {{- if eq .Type "main" }}
      {{.Name | ToLower}} := new(handlers.{{.Name}})
 	 {{.Name | ToLower}}.I{{.Name}} = &database.{{.Name}}DB{DB: session}
 	 {{- if .MessagingModelSpec.MessageRespondType}}
@@ -77,6 +78,7 @@ glog.Info("Application {{$.config.Project}} has started")
 	 {{.Name | ToLower}}Group.GET("/getAll/:skip/:limit", {{.Name | ToLower}}.GetAll{{.Name}}s())
 	 {{.Name | ToLower}}Group.GET("/getAllBy/:skip/:limit", {{.Name | ToLower}}.GetAll{{.Name}}sBy())
     }
+	{{- end}}
      {{end}}
     router.Run(":{{$.config.APISpec.Port}}")
 

--- a/examples/config_grpc_mongo.json
+++ b/examples/config_grpc_mongo.json
@@ -16,6 +16,7 @@
   "models": [
     {
       "name": "person",
+      "type":"main",
       "fields": [
         {
           "name": "name",
@@ -23,30 +24,56 @@
           "isKey": true
         },
         {
-          "name": "govtNo",
+          "name": "email",
+          "type": "string",
+          "isKey": true,
+          "validateExp": "^[a-zA-Z0-9.!#$%&'*+\\\\/=?^_\\\\`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+        },
+        {
+          "name": "gender",
+          "type": "string"
+        },
+        {
+          "name": "contact",
           "type": "long"
         },
         {
-          "name": "isIndian",
-          "type": "bool"
-        },
-        {
-          "name": "email",
-          "type": "string",
-          "validateExp": "[a-zA-Z0-9]",
-          "isKey": true
-        },
-        {
-          "name": "mobile",
-          "type": "string"
-        },
-        {
           "name": "status",
-          "type": "string"
+          "type": "global.GetDefaultStr(`active`)"
         },
         {
           "name": "lastModified",
           "type": "global.GetCurrentDateTimeInStr()"
+        },
+        {
+          "name": "Address",
+          "type": "Address"
+        }
+      ]
+    },
+    {
+      "name": "Address",
+      "type":"sub",
+      "fields": [
+        {
+          "name": "addressline",
+          "type": "string"
+        },
+        {
+          "name": "street",
+          "type": "string"
+        },
+        {
+          "name": "state",
+          "type": "string"
+        },
+        {
+          "name": "country",
+          "type": "string"
+        },
+        {
+          "name": "zip",
+          "type": "string"
         }
       ]
     }

--- a/examples/config_grpc_mongo_product.json
+++ b/examples/config_grpc_mongo_product.json
@@ -16,6 +16,7 @@
   "models": [
     {
       "name": "product",
+      "type":"main",
       "fields": [
         {
           "name": "name",
@@ -51,6 +52,7 @@
     },
     {
       "name": "Address",
+      "type":"sub",
       "fields": [
         {
           "name": "name",

--- a/examples/config_grpc_sql_mysql.json
+++ b/examples/config_grpc_sql_mysql.json
@@ -16,6 +16,7 @@
     "models": [
       {
         "name": "product",
+        "type":"main",
         "fields": [
           {
             "name": "name",
@@ -51,6 +52,7 @@
       },
       {
         "name": "Address",
+        "type":"sub",
         "fields": [
           {
             "name": "name",

--- a/examples/config_grpc_sql_pg.json
+++ b/examples/config_grpc_sql_pg.json
@@ -16,6 +16,7 @@
     "models": [
       {
         "name": "product",
+        "type":"main",
         "fields": [
           {
             "name": "name",
@@ -51,6 +52,7 @@
       },
       {
         "name": "Address",
+        "type":"sub",
         "fields": [
           {
             "name": "name",

--- a/examples/config_http_mongo.json
+++ b/examples/config_http_mongo.json
@@ -16,6 +16,7 @@
   "models": [
     {
       "name": "person",
+      "type":"main",
       "fields": [
         {
           "name": "name",
@@ -52,6 +53,7 @@
     },
     {
       "name": "Address",
+      "type":"sub",
       "fields": [
         {
           "name": "addressline",

--- a/examples/config_http_mongo_nats.json
+++ b/examples/config_http_mongo_nats.json
@@ -21,6 +21,7 @@
   "models": [
     {
       "name": "person",
+      "type":"main",
       "messagingModelSpec": {
         "messageRespondType": "publish",
         "topic": "person_topic"
@@ -65,6 +66,7 @@
     },
     {
       "name": "Address",
+      "type":"sub",
       "fields": [
         {
           "name": "addressline",

--- a/examples/config_http_sql_mysql.json
+++ b/examples/config_http_sql_mysql.json
@@ -16,6 +16,7 @@
     "models": [
       {
         "name": "person",
+        "type":"main",
         "fields": [
           {
             "name": "name",

--- a/examples/config_http_sql_pg.json
+++ b/examples/config_http_sql_pg.json
@@ -16,6 +16,7 @@
   "models": [
     {
       "name": "person",
+      "type":"main",
       "fields": [
         {
           "name": "name",

--- a/examples/grpc_mongo_eduempower.json
+++ b/examples/grpc_mongo_eduempower.json
@@ -21,6 +21,7 @@
     "models": [
         {
             "name": "user",
+            "type":"main",
             "messagingModelSpec": {
                 "messageRespondType": "publish",
                 "topic": "users_topic"
@@ -69,6 +70,7 @@
         },
         {
             "name": "userDetails",
+            "type":"sub",
             "fields": [
                 {
                     "name": "email",
@@ -80,6 +82,7 @@
         },
         {
             "name": "address",
+            "type":"sub",
             "fields": [
                 {
                     "name": "addressline",
@@ -105,6 +108,7 @@
         },
         {
             "name": "individual",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -138,6 +142,7 @@
         },
         {
             "name": "organization",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -176,6 +181,7 @@
         
         {
             "name": "fund",
+            "type":"main",
             "fields": [
                 {
                     "name": "donorEmail",

--- a/examples/http_mongo_eduempower_err.json
+++ b/examples/http_mongo_eduempower_err.json
@@ -21,6 +21,7 @@
     "models": [
         {
             "name": "user",
+            "type":"main",
             "messagingModelSpec": {
                 "messageRespondType": "publish",
                 "topic": "users_topic"
@@ -69,6 +70,7 @@
         },
         {
             "name": "userDetails",
+            "type":"sub",
             "fields": [
                 {
                     "name": "email",
@@ -80,6 +82,7 @@
         },
         {
             "name": "individual",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -129,6 +132,7 @@
         },
         {
             "name": "organization",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -182,6 +186,7 @@
         },
         {
             "name":"fund",
+            "type":"main",
             "fields":[
                 {
                     "name":"donorEmail",

--- a/examples/http_postgres_eduempower.json
+++ b/examples/http_postgres_eduempower.json
@@ -22,6 +22,7 @@
     "models": [
         {
             "name": "user",
+            "type":"main",
             "messagingModelSpec": {
                 "messageRespondType": "publish",
                 "topic": "users_topic"
@@ -70,6 +71,7 @@
         },
         {
             "name": "userDetails",
+            "type":"sub",
             "fields": [
                 {
                     "name": "email",
@@ -81,6 +83,7 @@
         },
         {
             "name": "individual",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -130,6 +133,7 @@
         },
         {
             "name": "organization",
+            "type":"main",
             "fields": [
                 {
                     "name": "user",
@@ -183,6 +187,7 @@
         },
         {
             "name":"fund",
+            "type":"main",
             "fields":[
                 {
                     "name":"donorEmail",

--- a/generate/types.go
+++ b/generate/types.go
@@ -34,7 +34,7 @@ type Generate struct {
 // Model is to hold model data from configuration file
 type Model struct {
 	Name               string             `json:"name" yaml:"name"`
-	Type               string             `json:"type" yaml:"type"` // model type can be main or sub. If main methods and all other things are created
+	Type               string             `json:"type" yaml:"type"` // model type can be main or sub or both.
 	MessagingModelSpec MessagingModelSpec `json:"messagingModelSpec" yaml:"messagingModelSpec"`
 	Fields             []Field            `json:"fields" yaml:"fields"`
 }

--- a/generate/validators.go
+++ b/generate/validators.go
@@ -86,6 +86,10 @@ func (tg *Generate) Validate() (err error) {
 		if ok {
 			return errors.New(" Duplicate model names:" + m.Name)
 		}
+		// Accept only Model types as main | sub | both
+		if m.Type != "main" && m.Type != "sub" && m.Type != "both" {
+			return errors.New("Model type should be main | sub |both")
+		}
 		modelMap[strings.ToLower(m.Name)] = "noted"
 		fieldMap := make(map[string]string)
 		for _, f := range m.Fields {
@@ -96,7 +100,7 @@ func (tg *Generate) Validate() (err error) {
 			fieldMap[strings.ToLower(f.Name)] = "noted"
 
 		}
-		if tg.DatabaseSpec.Name == "mongo" {
+		if tg.DatabaseSpec.Name == "mongo" && m.Type == "main" {
 			_, ok := fieldMap["id"]
 			if !ok {
 				id := Field{Name: "ID", Type: "string", Category: "scaler"}
@@ -106,7 +110,7 @@ func (tg *Generate) Validate() (err error) {
 			//  todo if the type of the field for id is not string .. it has to be string
 			//	}
 		}
-		if tg.DatabaseSpec.Kind == "sql" {
+		if tg.DatabaseSpec.Kind == "sql" && m.Type == "main" {
 			_, ok := fieldMap["id"]
 			if !ok {
 				id := Field{Name: "ID", Type: "int", Category: "scaler"}

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -26,10 +26,11 @@ type Mapping struct {
 
 // OpsData contains what is the source and destination
 type OpsData struct {
-	OpType string `json:"opType"`
-	Src    string `json:"src"`
-	Dst    string `json:"dst"`
-	Ext    string `json:"ext"`
+	OpType     string `json:"opType"`
+	Src        string `json:"src"`
+	Dst        string `json:"dst"`
+	Ext        string `json:"ext"`
+	GenForType string `json:"genForType"`
 }
 
 // New creates a new Mapping


### PR DESCRIPTION
- Only model type main can have all crud db operations logic 
- Only model type main can have all handlers for http or grpc
- Model type sub is just for the sub model purpose to help main models. 
- Example Person is a model .. Address is a sub model hence Address does not need Database operations or handlers etc